### PR TITLE
Add dark style support for elementary OS 6

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -39,6 +39,19 @@ namespace Soundy {
 
             var settings = Soundy.Settings.get_instance();
             var speaker_host = settings.get_speaker_host();
+            
+            var granite_settings = Granite.Settings.get_default ();
+            var gtk_settings = Gtk.Settings.get_default ();
+            
+            gtk_settings.gtk_application_prefer_dark_theme = (
+                granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK
+            );
+            
+            granite_settings.notify["prefers-color-scheme"].connect (() => {
+                gtk_settings.gtk_application_prefer_dark_theme = (
+                    granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK
+                );
+            });
 
             message(@"trying to connecto to $speaker_host");
 


### PR DESCRIPTION
Added dark style support for elementary OS 6. The app now dynamically between dark and light style according to the settings.

PS I couldn't record the screen on elementary OS 6. But I've tested it and the feature works.

Closes #26 